### PR TITLE
Upgrade web3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-dom": "16.8.4",
     "react-scripts": "2.1.3",
     "truffle": "5.0.5",
-    "web3": "1.0.0-beta.55"
+    "web3": "^1.2.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -39,7 +39,7 @@ class App extends Component {
     const networkId = await web3.eth.net.getId()
     const networkData = SocialNetwork.networks[networkId]
     if(networkData) {
-      const socialNetwork = web3.eth.Contract(SocialNetwork.abi, networkData.address)
+      const socialNetwork = new web3.eth.Contract(SocialNetwork.abi, networkData.address)
       this.setState({ socialNetwork })
       const postCount = await socialNetwork.methods.postCount().call()
       this.setState({ postCount })


### PR DESCRIPTION
The receipt from `socialNetwork.methods.createPost(name).send()` isn't returned when using `web3@1.0.0-beta.55`.

The problem has gone when I have updated web3 to version 1.2.6 .